### PR TITLE
fix(scripts): Fix install scripts to install by one key for k8s 1.14.8

### DIFF
--- a/scripts/installation/install.sh
+++ b/scripts/installation/install.sh
@@ -4,7 +4,7 @@
 # kubebernets 1.14.8 is test ok.
 # istio version: v1.2.2
 # seldon core: v1.2.2
-# harbor: v2.1.0
+# harbor: v2.1.1
 # klever 0.1.0
 ############# Version Information End ###############
 
@@ -31,7 +31,7 @@ CWD=$(pwd)
 curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.2.2 sh -
 # If install patch in k8s 1.14.8
 # Please reference https://github.com/istio/istio/issues/22366
-cp -rf $CWD/klever-model-registry/scripts/patch/istio/istio-1.2.2/install/kubernetes/helm/istio/charts/gateways/templates/* $CWD/istio/istio-1.2.2/install/kubernetes/helm/istio/charts/gateways
+cp -rf $CWD/klever-model-registry/scripts/installation/patch/istio/istio-1.2.2/install/kubernetes/helm/istio/charts/gateways/templates/* $CWD/istio-1.2.2/install/kubernetes/helm/istio/charts/gateways/templates
 kubectl create namespace istio-system
 helm template istio-init $CWD/istio-1.2.2/install/kubernetes/helm/istio-init --namespace istio-system | kubectl apply -f -
 kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
@@ -44,7 +44,7 @@ helm template istio $CWD/istio-1.2.2/install/kubernetes/helm/istio --namespace i
 # patch point ref https://github.com/goharbor/harbor-helm/blob/v1.5.1/templates/core/core-dpl.yaml#L45-L52.
 kubectl create namespace harbor-system
 git clone https://github.com/goharbor/harbor-helm.git
-cp -rf $CWD/klever-model-registry/scripts/patch/harbor-helm/templates/core/* $CWD/harbor-helm/templates/core/
+cp -rf $CWD/klever-model-registry/scripts/installation/patch/harbor-helm/templates/core/* $CWD/harbor-helm/templates/core/
 helm install harbor ./harbor-helm \
     --set expose.nodePort.ports.http.nodePort=$HARBOR_PORT \
     --set expose.type=nodePort \
@@ -61,9 +61,10 @@ helm install harbor ./harbor-helm \
 #
 # Install seldon, please reference https://docs.seldon.io/projects/seldon-core/en/latest/charts/seldon-core-operator.html
 #
-git clone https://github.com/kleveross/seldon-core.git
+wget https://github.com/SeldonIO/seldon-core/archive/v1.2.2.tar.gz
 kubectl create namespace seldon-system
-helm install seldon-core $CWD/seldon-core/helm-charts/seldon-core-operator \
+tar -zxvf v1.2.2.tar.gz
+helm install seldon-core $CWD/seldon-core-1.2.2/helm-charts/seldon-core-operator \
     --set usageMetrics.enabled=true \
     --set istio.enabled=true \
     --set istio.gateway=istio-system/kleveross-gateway \
@@ -97,3 +98,4 @@ git clone https://github.com/kleveross/klever-web
 helm install klever-web $CWD/klever-web/manifests/klever-web \
     --namespace=kleveross-system \
     --set service.nodePort=$KLEVER_WEB_PORT
+    --set model.registry.address=http://$MASTER_IP:$KLEVER_MODEL_REGISTRY_PORT


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Fix install scripts to install by one key for k8s 1.14.8 

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @FogDong @hewenguang 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Fix install scripts to install by one key for k8s 1.14.8 
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
